### PR TITLE
`middlewares` should be `middleware` in `@types/koa-router`

### DIFF
--- a/types/koa-router/index.d.ts
+++ b/types/koa-router/index.d.ts
@@ -219,7 +219,7 @@ declare class Router {
     /**
      * Returns router middleware which dispatches a route matching the request.
      */
-    middlewares(): Router.IMiddleware;
+    middleware(): Router.IMiddleware;
 
     /**
      * Returns separate middleware for responding to `OPTIONS` requests with


### PR DESCRIPTION
`middlewares` should be `middleware`

https://github.com/alexmingoia/koa-router/blob/master/lib/router.js#L314

Please fill in this template.

- [x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x ] Test the change in your own code. (Compile and run.)
- [x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
